### PR TITLE
Correcting regex match

### DIFF
--- a/support/rewrite-hooks.sh
+++ b/support/rewrite-hooks.sh
@@ -11,7 +11,7 @@ do
       continue 
     fi
 
-    if [[ "$dir" =~ ^.*.git$ ]]
+    if [[ "$dir" =~ ^.*\.git$ ]]
     then
       project_hook="$src/$dir/hooks/post-receive"
       gitolite_hook="/home/git/gitlab-shell/hooks/post-receive"
@@ -23,7 +23,7 @@ do
     else
       for subdir in `ls "$src/$dir/"`
       do
-        if [ -d "$src/$dir/$subdir" ] && [[ "$subdir" =~ ^.*.git$ ]]; then
+        if [ -d "$src/$dir/$subdir" ] && [[ "$subdir" =~ ^.*\.git$ ]]; then
           project_hook="$src/$dir/$subdir/hooks/post-receive"
           gitolite_hook="/home/git/gitlab-shell/hooks/post-receive"
           ln -s -f $gitolite_hook $project_hook


### PR DESCRIPTION
Stops paths such as test_git, testgit etc.. being matched
