### PR TITLE
Disable SSL cert verification when using RVM.

### DIFF
--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -36,6 +36,8 @@ class GitlabNet
     url = URI.parse(url)
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = (url.port == 443)
+    `rvm --version`
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ($? && http.use_ssl?)
     request = Net::HTTP::Get.new(url.request_uri)
     http.start {|http| http.request(request) }
   end


### PR DESCRIPTION
This should mostly only be used when gitlabhq and gitlab-shell are
on the same physical machine.

Using rvm, when running ./bin/check the following error occurs:

```
Check GitLab API access: /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/net/http.rb:799:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)
    from /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/net/http.rb:799:in `block in connect'
    from /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/timeout.rb:54:in `timeout'
    from /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/timeout.rb:99:in `timeout'
    from /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/net/http.rb:799:in `connect'
    from /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/net/http.rb:755:in `do_start'
    from /home/git/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/net/http.rb:744:in `start'
    from /home/git/gitlab-shell/lib/gitlab_net.rb:47:in `get'
    from /home/git/gitlab-shell/lib/gitlab_net.rb:27:in `check'
    from ./gitlab-shell/bin/check:11:in `<main>'

```

for some reason, solutions posted across the net (such as setting http.ca_path and http.ca_file) don't work.
