### PR TITLE
Allow admins full ssh access

### DIFF
--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -24,7 +24,7 @@ class GitlabKeys
   protected
 
   def add_key
-    cmd = "command=\"#{ROOT_PATH}/bin/gitlab-shell #{@key_id}\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty #{@key}"
+    cmd = "command=\"#{ROOT_PATH}/bin/gitlab-shell #{@key_id}\",no-port-forwarding,no-X11-forwarding #{@key}"
     cmd = "echo \'#{cmd}\' >> #{auth_file}"
     system(cmd)
   end

--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -18,6 +18,15 @@ class GitlabNet
     !!(resp.code == '200' && resp.body == 'true')
   end
 
+  def admin?(key)
+    key_id = key.gsub("key-", "")
+
+    url = "#{host}/admin?key_id=#{key_id}"
+
+    resp = get(url)
+
+    !!(resp.code == '200' && resp.body == 'true')
+  end
   def discover(key)
     key_id = key.gsub("key-", "")
     resp = get("#{host}/discover?key_id=#{key_id}")

--- a/spec/gitlab_keys_spec.rb
+++ b/spec/gitlab_keys_spec.rb
@@ -14,7 +14,7 @@ describe GitlabKeys do
     let(:gitlab_keys) { build_gitlab_keys('add-key', 'key-741', 'ssh-rsa AAAAB3NzaDAxx2E') }
 
     it "should receive valid cmd" do
-      valid_cmd = "echo 'command=\"#{ROOT_PATH}/bin/gitlab-shell key-741\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-rsa AAAAB3NzaDAxx2E' >> #{GitlabConfig.new.auth_file}"
+      valid_cmd = "echo 'command=\"#{ROOT_PATH}/bin/gitlab-shell key-741\",no-port-forwarding,no-X11-forwarding ssh-rsa AAAAB3NzaDAxx2E' >> #{GitlabConfig.new.auth_file}"
       gitlab_keys.should_receive(:system).with(valid_cmd)
       gitlab_keys.send :add_key
     end

--- a/spec/gitlab_net_spec.rb
+++ b/spec/gitlab_net_spec.rb
@@ -60,4 +60,22 @@ describe GitlabNet, vcr: true do
       end
     end
   end
+
+  describe :admin? do
+    context 'ssh key for an admin account' do
+      it 'should return true' do
+        VCR.use_cassette("is-admin") do
+          gitlab_net.should be_admin('key-1')
+        end
+      end
+    end
+
+    context 'ssh key for a non-admin account' do
+      it 'should return false' do
+        VCR.use_cassette("is-not-admin") do
+          gitlab_net.should_not be_admin('key-2')
+        end
+      end
+    end
+  end
 end

--- a/spec/vcr_cassettes/is-admin.yml
+++ b/spec/vcr_cassettes/is-admin.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev.gitlab.org/api/v3/internal/admin?key_id=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.1.19
+      Date:
+      - Thu, 14 Mar 2013 15:21:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Request-Id:
+      - 5c9e186eeed35fe963adf4a6e707804e
+      X-Runtime:
+      - '0.035379'
+      X-Rack-Cache:
+      - miss
+    body:
+      encoding: US-ASCII
+      string: 'true'
+    http_version:
+  recorded_at: Thu, 14 Mar 2013 15:21:06 GMT
+recorded_with: VCR 2.4.0

--- a/spec/vcr_cassettes/is-not-admin.yml
+++ b/spec/vcr_cassettes/is-not-admin.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev.gitlab.org/api/v3/internal/admin?key_id=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.1.19
+      Date:
+      - Thu, 14 Mar 2013 15:21:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Request-Id:
+      - e67e002f94cca815f3bcd7b945950648
+      X-Runtime:
+      - '0.004122'
+      X-Rack-Cache:
+      - miss
+    body:
+      encoding: US-ASCII
+      string: 'false'
+    http_version:
+  recorded_at: Thu, 14 Mar 2013 15:21:07 GMT
+recorded_with: VCR 2.4.0


### PR DESCRIPTION
This feature allows anyone who is an admin in gitlab normal SSH
access, including starting a tty session; in effect causing
gitlab-shell to become transparent to admins.

I wrote this so capistrano will continue to work without major
kludges (like sudo).

If GitLab isn't running, then gitlab-shell will deny access
to admins (unfortunately).

This feature requires a new GitLab internal api call, "admin", to
check if a given SSH key belongs to an unblocked admin.

When I made these changes, I also replaced `system()` calls with
`Kernel::exec()` because there is no need to keep the ruby process
around once we've authenticated the user.
