### PR TITLE
http_settings configuration option added.

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,8 +1,13 @@
 # GitLab user. git by default
 user: git
 
-# Url to gitlab instance. Used for api calls
+# Url to gitlab instance. Used for api calls. Should be ends with slash.
 gitlab_url: "http://localhost/"
+
+http_settings:
+#  user: someone
+#  password: somepass
+  self_signed_cert: false
 
 # Repositories path
 repos_path: "/home/git/repositories"

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -18,4 +18,8 @@ class GitlabConfig
   def gitlab_url
     @config['gitlab_url'] ||= "http://localhost/"
   end
+
+  def http_settings
+    @config['http_settings'] ||= {}
+  end
 end


### PR DESCRIPTION
Now it supports:
- self_signed_cert option to allow self-signed certificates over https protocol.
- user and password options to pass though http auth.
