### PR TITLE
Require openssl

### DIFF
--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'openssl'
 require 'json'
 
 require_relative 'gitlab_config'


### PR DESCRIPTION
Fix the "uninitialized constant GitlabNet::OpenSSL (NameError)"
after upgrading to ruby 2.0
