### PR TITLE
Allow to set gitlab_url with or without trailing slash.

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,7 +1,7 @@
 # GitLab user. git by default
 user: git
 
-# Url to gitlab instance. Used for api calls. Should be ends with slash.
+# Url to gitlab instance. Used for api calls.
 gitlab_url: "http://localhost/"
 
 http_settings:

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -16,7 +16,10 @@ class GitlabConfig
   end
 
   def gitlab_url
-    @config['gitlab_url'] ||= "http://localhost/"
+    @gitlab_url ||= begin
+      url = @config['gitlab_url'] || "http://localhost"
+      url = $1  if url =~ /\A(.+)\/\z/
+    end
   end
 
   def http_settings


### PR DESCRIPTION
Actually gitlab_url should be applied without trailing slash.
