### PR TITLE
Adding some simple ssl verification precautions and config options.

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -17,8 +17,10 @@ end
 
 puts "\nCheck directories and files: "
 
-config = GitlabConfig.new
+config = $gitlabConfig
 dirs = [config.repos_path, config.auth_file]
+dirs.push(config.http_settings['ssl_ca_path']) if not config.http_settings['ssl_ca_path'].nil?
+dirs.push(config.http_settings['ssl_ca_file']) if not config.http_settings['ssl_ca_file'].nil?
 
 dirs.each do |dir|
   print "\t#{dir}: "

--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,7 @@ require_relative '../lib/gitlab_init'
 # GitLab shell, invoked from ~/.ssh/authorized_keys
 #
 
-config = GitlabConfig.new
+config = $gitlabConfig
 key_dir = File.dirname("#{config.auth_file}")
 
 commands = [

--- a/config.yml.example
+++ b/config.yml.example
@@ -7,6 +7,12 @@ gitlab_url: "http://localhost/"
 http_settings:
 #  user: someone
 #  password: somepass
+#  use_ssl: false
+#  ssl_version: TLSv1_client
+# These two options are mutually exclusive with _file being preferred
+#  ssl_ca_path: /etc/ssl/certs
+#  ssl_ca_file: /etc/ssl/cert.pem
+#  ssl_verify_depth: 2
   self_signed_cert: false
 
 # Repositories path
@@ -14,3 +20,9 @@ repos_path: "/home/git/repositories"
 
 # File used as authorized_keys for gitlab user
 auth_file: "/home/git/.ssh/authorized_keys"
+
+# Access log
+access_log: "gitlab-shell_access.log"
+
+# Error log
+error_log: "gitlab-shell_error.log"

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -1,10 +1,79 @@
 require 'yaml'
+require 'net/http'
+require 'logger'
 
-class GitlabConfig
-  attr_reader :config
+$gitlabConfig = Object.new
+class << $gitlabConfig
+  attr_reader :config, :http_opts, :logger
 
-  def initialize
+  def setup
     @config = YAML.load_file(File.join(ROOT_PATH, 'config.yml'))
+    @http_opts = Hash.new
+
+    # Setup our logger
+    @logger = Logger.new(error_log) if not error_log.nil?   # Probably needs pretty error message
+    @logger = Logger.new('/dev/null') if @logger.nil?
+    @logger.level = Logger::INFO
+    
+    @config["base_url"] = URI.parse(base_url.to_s + '/api/v3/internal')
+    @config["gitlab_url"] = base_url.to_s
+
+    # If our url scheme is https or we're explicitly told to use https turn it on
+    if ((base_url.scheme == 'https') or \
+      ((not http_settings['use_ssl'].nil? ) \
+        and \
+       (http_settings['use_ssl'] == true)) \
+      )
+
+      # Update our urls to be correct in memory in case of config conflict
+      # Prefer to accidentally use https on an http url than vice versa!
+      @config["base_url"].scheme = "https"
+      @config["gitlab_url"] = @config["base_url"].to_s
+      @http_opts[:use_ssl] = true
+
+      if not http_settings['ssl_version'].nil?
+        @http_opts[:ssl_version] = http_settings['ssl_version']
+      else
+        @http_opts[:ssl_version] = :TLSv1_client
+      end
+
+      @logger.debug {"Using TLS! base #{@config["gitlab_url"]} ver: #{@http_opts[:ssl_version].to_s}"}
+
+      if not http_settings['self_signed_cert'].nil? and http_settings['self_signed_cert'] == true
+        @http_opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
+        @logger.error {"NOT VERIFYING X509 HOSTNAMES OR CERTIFICATION PATHS!!!"}
+      else
+        @http_opts[:verify_mode] = OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+        if not http_settings['verify_depth'].nil? and http_settings['verify_depth'] <= 65535
+          @http_opts[:verify_depth] = http_settings['verify_depth']
+        else
+          @http_opts[:verify_depth] = 2
+        end
+
+        if not http_settings['ssl_ca_file'].nil?
+          throw Errno::EACCES unless File.open(http_settings['ssl_ca_file'],'r') {|s| true}
+          @http_opts[:ca_file] = http_settings['ssl_ca_file']
+        elsif not http_settings['ssl_ca_path'].nil?
+          throw Errno::EACCES unless Dir.open(http_settings['ssl_ca_path'],'r') {|s| true}
+          @http_opts[:ca_path] = http_settings['ssl_ca_path']
+        else
+          @logger.error("Using system configuration for TLS/X509 ca path validation. Set ssl_ca_path or ssl_ca_file http_settings to silence this message.")
+          if File.exists?('/etc/ssl/cert.pem') # FreeBSD ca_root_nss port
+            @http_opts[:ca_file] = '/etc/ssl/cert.pem'
+          elsif File.exists?('/usr/local/share/certs/ca-root-nss.crt') # FreeBSD ca_root_nss port
+            @http_opts[:ca_file] = '/usr/local/share/certs/ca-root-nss.crt'
+          elsif File.exists?('/opt/local/share/curl/curl-ca-bundle.crt') # Mac OS X macports
+            @http_opts[:ca_file] = '/opt/local/share/curl/curl-ca-bundle.crt'
+          elsif File.exists?('/etc/ssl/certs') # Ubuntu
+            @http_opts[:ca_path] = '/etc/ssl/certs'
+          else
+            @logger.error {"Could not find fallback TLS/X509 ca path! Hope your environment is sane!"}
+          end
+        end
+        @logger.info {"Validating X509 Certificates using file #{@http_opts[:ca_file]} ."} if not @http_opts[:ca_file].nil?
+        @logger.info {"Validating X509 Certificates using path #{@http_opts[:ca_path]} ."} if not @http_opts[:ca_path].nil?
+      end
+    end
   end
 
   def repos_path
@@ -19,7 +88,20 @@ class GitlabConfig
     @config['gitlab_url'] ||= "http://localhost/"
   end
 
+  def base_url
+    @config['base_url'] ||= URI.parse(gitlab_url)
+  end
+
   def http_settings
     @config['http_settings'] ||= {}
   end
+
+  def access_log
+    @config['access_log'] ||= "/home/git/gitlab/log/gitlab-shell_access.log"
+  end
+
+  def error_log
+    @config['error_log'] ||= "/home/git/gitlab/log/gitlab-shell_error.log"
+  end
 end
+$gitlabConfig.setup

--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -9,7 +9,7 @@ class GitlabKeys
     @command = ARGV.shift
     @key_id = ARGV.shift
     @key = ARGV.shift
-    @auth_file = GitlabConfig.new.auth_file
+    @auth_file = $gitlabConfig.auth_file
   end
 
   def exec

--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -14,6 +14,7 @@ class GitlabNet
 
     url = "#{host}/allowed?key_id=#{key_id}&action=#{cmd}&ref=#{ref}&project=#{project_name}"
 
+    config.logger.debug {"Trying #{url} ."}
     resp = get(url)
 
     !!(resp.code == '200' && resp.body == 'true')
@@ -21,32 +22,124 @@ class GitlabNet
 
   def discover(key)
     key_id = key.gsub("key-", "")
+    config.logger.debug {"Trying #{host}/discover?key_id=#{key_id} ."}
     resp = get("#{host}/discover?key_id=#{key_id}")
     JSON.parse(resp.body) rescue nil
   end
 
   def check
+    config.logger.debug {"Trying #{host}/check ."}
     get("#{host}/check")
   end
 
   protected
 
+  def base_uri
+    config.base_url
+  end
+
   def config
-    @config ||= GitlabConfig.new
+    @config ||= $gitlabConfig
   end
 
   def host
-    "#{config.gitlab_url}/api/v3/internal"
+    config.gitlab_url
+  end
+
+  def http
+    if @http.nil?
+      @http = Net::HTTP.new(base_uri.host, base_uri.port)
+      unless config.http_opts[:use_ssl].nil? or config.http_opts[:use_ssl] == false
+        http.use_ssl = config.http_opts[:use_ssl]
+        http.verify_mode = config.http_opts[:verify_mode]
+        http.verify_depth = config.http_opts[:verify_depth]
+        http.ca_file = config.http_opts[:ca_file]
+        http.ca_path = config.http_opts[:ca_path]
+        # This is a first attempt at sane ssl cert verification.
+        # subjectAltName and CN checking
+        http.verify_callback = lambda do |preverify_ok, ssl_context|
+          # Newer Ruby uses keyed siphash for it's hashes so this is pretty safe to use
+          # as a known cert lookup table in this fashion. If ruby in use doesn't it should
+          # be upgarded as the previous hash used is easily collidable and this could be
+          # tricked with malformed subjectAltNames/CNs (though we only connect to one host ...)
+          if @known_certs.nil?
+            @known_certs = Hash.new
+          end
+          success = false
+          have_altname = false
+          cert = ssl_context.chain[0] if not ssl_context.chain[0].nil?
+          return false if cert.nil?
+
+          # Compares two host names using browser/x509 wildcard matching rules
+          if @check_cert_name.nil?
+            @check_cert_name = lambda do |x,y|
+              success = false
+              fqdna = x.split('.')
+              hosta = y.split('.')
+              if fqdna[0] =~ /[*]/
+                fqdnf = fqdna[0].sub(/[*]/,'[^.]*')
+                hostf = hosta[0]
+                fqdna.delete_at[0]
+                hosta.delete_at[0]
+                if fqdna.join('.') == hosta.join('.')
+                  success = true if hostf =~ Regexp.new(fqdnf)
+                end
+              else
+                success = true if x == y
+              end
+              return success
+            end
+          end
+
+          # Cache verification based on keyed hash of the der form of the cert
+          if @remember_cert.nil?
+            @remember_cert = lambda do |match,host,cert|
+              if @known_certs[cert.to_der.hash].nil?
+                @known_certs[cert.to_der.hash] = Hash.new
+              end
+              @known_certs[cert.to_der.hash].store(host.hash, match)
+            end
+          end
+
+          if  (not @known_certs[cert.to_der.hash].nil?) \
+            and \
+              (not @known_certs[cert.to_der.hash].fetch(base_uri.host.hash).nil?) \
+            and \
+              @check_cert_name.call(@known_certs[cert.to_der.hash].fetch(base_uri.host.hash),base_uri.host)
+            success = (preverify_ok && true)
+          elsif preverify_ok
+            # First we look for subjectAltNames that match our host! (rfc2818)
+            cert.extensions.each do |ext|
+              if (ext.oid == 'subjectAltName')
+                have_altname = true
+                ext.value.split(', ').each do |v|
+                  v.sub!(/^(DNS|IP):/,'')
+                  success = true if @check_cert_name.call(v,base_uri.host)
+                  if success
+                    @remember_cert.call(v,base_uri.host,cert)
+                    break 2
+                  end
+                end
+              end
+            end
+            # Fallback to matching the CN - We only match against the longest CN value in the subject.
+            # This should be correct per rfc2818 as the longest will be the most specific.
+            if not have_altname
+              certcn = (cert.subject.to_s.match(/\/CN=([^\/]+)\//).captures)[0]
+              success = true if @check_cert_name.call(certcn,base_uri.host)
+              @remember_cert.call(certcn,base_uri.host,cert) if success
+            end
+            # Verification fails!
+          end
+          return success
+        end
+      end
+    end
+    @http
   end
 
   def get(url)
     url = URI.parse(url)
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = (url.port == 443)
-
-    if config.http_settings['self_signed_cert'] && http.use_ssl?
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    end
 
     request = Net::HTTP::Get.new(url.request_uri)
     if config.http_settings['user'] && config.http_settings['password']

--- a/lib/gitlab_projects.rb
+++ b/lib/gitlab_projects.rb
@@ -19,7 +19,7 @@ class GitlabProjects
   def initialize
     @command = ARGV.shift
     @project_name = ARGV.shift
-    @repos_path = GitlabConfig.new.repos_path
+    @repos_path = $gitlabConfig.repos_path
     @full_path = File.join(@repos_path, @project_name)
   end
 

--- a/lib/gitlab_shell.rb
+++ b/lib/gitlab_shell.rb
@@ -8,7 +8,7 @@ class GitlabShell
   def initialize
     @key_id = ARGV.shift
     @origin_cmd = ENV['SSH_ORIGINAL_COMMAND']
-    @repos_path = GitlabConfig.new.repos_path
+    @repos_path = $gitlabConfig.repos_path
   end
 
   def exec

--- a/lib/gitlab_update.rb
+++ b/lib/gitlab_update.rb
@@ -5,7 +5,7 @@ class GitlabUpdate
   def initialize(repo_path, key_id, refname)
     @repo_path = repo_path.strip
     @repo_name = repo_path
-    @repo_name.gsub!(GitlabConfig.new.repos_path.to_s, "")
+    @repo_name.gsub!($gitlabConfig.repos_path.to_s, "")
     @repo_name.gsub!(/\.git$/, "")
     @repo_name.gsub!(/^\//, "")
 

--- a/spec/gitlab_keys_spec.rb
+++ b/spec/gitlab_keys_spec.rb
@@ -14,7 +14,7 @@ describe GitlabKeys do
     let(:gitlab_keys) { build_gitlab_keys('add-key', 'key-741', 'ssh-rsa AAAAB3NzaDAxx2E') }
 
     it "should receive valid cmd" do
-      valid_cmd = "echo 'command=\"#{ROOT_PATH}/bin/gitlab-shell key-741\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-rsa AAAAB3NzaDAxx2E' >> #{GitlabConfig.new.auth_file}"
+      valid_cmd = "echo 'command=\"#{ROOT_PATH}/bin/gitlab-shell key-741\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-rsa AAAAB3NzaDAxx2E' >> #{$gitlabConfig.auth_file}"
       gitlab_keys.should_receive(:system).with(valid_cmd)
       gitlab_keys.send :add_key
     end
@@ -24,7 +24,7 @@ describe GitlabKeys do
     let(:gitlab_keys) { build_gitlab_keys('rm-key', 'key-741', 'ssh-rsa AAAAB3NzaDAxx2E') }
 
     it "should receive valid cmd" do
-      valid_cmd = "sed -i '/shell key-741/d' #{GitlabConfig.new.auth_file}"
+      valid_cmd = "sed -i '/shell key-741/d' #{$gitlabConfig.auth_file}"
       gitlab_keys.should_receive(:system).with(valid_cmd)
       gitlab_keys.send :rm_key
     end

--- a/spec/gitlab_shell_spec.rb
+++ b/spec/gitlab_shell_spec.rb
@@ -17,7 +17,7 @@ describe GitlabShell do
   end
   let(:key_id) { "key-#{rand(100) + 100}" }
   let(:repository_path) { "/home/git#{rand(100)}/repos" }
-  before { GitlabConfig.any_instance.stub(:repos_path).and_return(repository_path) }
+  before { $gitlabConfig.stub(:repos_path).and_return(repository_path) }
 
   describe :initialize do
     before { ssh_cmd 'git-receive-pack' }

--- a/spec/vcr_cassettes/allowed-pull.yml
+++ b/spec/vcr_cassettes/allowed-pull.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/allowed?action=git-receive-pack&key_id=1&project=gitlab/gitlabhq&ref=master
+    uri: http://localhost/api/v3/internal/allowed?action=git-receive-pack&key_id=1&project=gitlab/gitlabhq&ref=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/allowed-push.yml
+++ b/spec/vcr_cassettes/allowed-push.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/allowed?action=git-upload-pack&key_id=1&project=gitlab/gitlabhq&ref=master
+    uri: http://localhost/api/v3/internal/allowed?action=git-upload-pack&key_id=1&project=gitlab/gitlabhq&ref=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/check-ok.yml
+++ b/spec/vcr_cassettes/check-ok.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/check
+    uri: http://localhost/api/v3/internal/check
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/denied-pull.yml
+++ b/spec/vcr_cassettes/denied-pull.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/allowed?action=git-receive-pack&key_id=2&project=gitlab/gitlabhq&ref=master
+    uri: http://localhost/api/v3/internal/allowed?action=git-receive-pack&key_id=2&project=gitlab/gitlabhq&ref=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/denied-push.yml
+++ b/spec/vcr_cassettes/denied-push.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/allowed?action=git-upload-pack&key_id=2&project=gitlab/gitlabhq&ref=master
+    uri: http://localhost/api/v3/internal/allowed?action=git-upload-pack&key_id=2&project=gitlab/gitlabhq&ref=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/dev_gitlab_org.yml
+++ b/spec/vcr_cassettes/dev_gitlab_org.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/allowed?action=git-receive-pack&key_id=100&project=gitlab/gitlabhq&ref=master
+    uri: http://localhost/api/v3/internal/allowed?action=git-receive-pack&key_id=100&project=gitlab/gitlabhq&ref=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/discover-ok.yml
+++ b/spec/vcr_cassettes/discover-ok.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/discover?key_id=1
+    uri: http://localhost/api/v3/internal/discover?key_id=1
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This is just a rough improvement to make it overridable. I'm not sure how errors should be handled on non-existent files, should gitlab-shell abort? Not install? Either way this at least makes the certification path configurable and looks for some sane defaults.

This turned into a bit of a bigger change than anticipated. It also has initial support to start working on #36 .

Original issue is at gitlabhq/gitlabhq#3445 .

This pull only addresses the gitlab-shell side of things. Any https requests made inside the rails code also needs similar attention.
