### PR TITLE
https can be served also on non-standard port

### DIFF
--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -42,7 +42,7 @@ class GitlabNet
   def get(url)
     url = URI.parse(url)
     http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = (url.port == 443)
+    http.use_ssl = (url.scheme == 'https')
 
     if config.http_settings['self_signed_cert'] && http.use_ssl?
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
Allow to use gitlab-shell with https on non-standard port 443.
