### PR TITLE
Fix permissions for SSH with StricModes onn

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -12,7 +12,9 @@ key_dir = File.dirname("#{config.auth_file}")
 commands = [
   "mkdir -p #{config.repos_path}",
   "mkdir -p #{key_dir}",
+  "chmod 700 #{key_dir}",
   "touch #{config.auth_file}",
+  "chmod 600 #{config.auth_file}",
   "chmod -R ug+rwX,o-rwx #{config.repos_path}",
   "find #{config.repos_path} -type d -print0 | xargs -0 chmod g+s"
 ]


### PR DESCRIPTION
I've installed following the instructions on Fedora 18, and would be nice to leave the permissions nicely for
SSH daemons configured with StrictModes On (cause u can get as I got this... http://www.daveperrett.com/articles/2010/09/14/ssh-authentication-refused/)

Cheers!
