### PR TITLE
fix rm_key removing all keys *starting with* key_id

### DIFF
--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -31,7 +31,7 @@ class GitlabKeys
   end
 
   def rm_key
-    cmd = "sed -i '/shell #{@key_id}/d' #{auth_file}"
+    cmd = "sed -i '/shell #{@key_id}\"/d' #{auth_file}"
     system(cmd)
   end
 end


### PR DESCRIPTION
Adding a " to the sed pattern provides a boundary
