### PR TITLE
Add message that repes_path should be real path

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -10,6 +10,7 @@ http_settings:
   self_signed_cert: false
 
 # Repositories path
+# REPOS_PATH MUST NOT BE A SYMLINK!!!
 repos_path: "/home/git/repositories"
 
 # File used as authorized_keys for gitlab user


### PR DESCRIPTION
In the main gitlab config there is a message that this should be the real path, meaning it looks like it can be the symlinked path in this config, experience shows this is not the case.
