### PR TITLE
Regex used in rm-key command is too lax

### DIFF
--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -31,7 +31,7 @@ class GitlabKeys
   end
 
   def rm_key
-    cmd = "sed -i '/shell #{@key_id}/d' #{auth_file}"
+    cmd = "sed -i '/shell #{@key_id}\"/d' #{auth_file}"
     system(cmd)
   end
 end


### PR DESCRIPTION
Basically the issue is that 'gitlab-shell rm-key key-2' removes all keys that match "key-2" pattern. "key-20", "key-25", etc.
This change makes the regex used in the sed command more strict.
