### PR TITLE
Fix issue #8 (Authorized_keys).

### DIFF
--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -31,7 +31,7 @@ class GitlabKeys
   end
 
   def rm_key
-    cmd = "sed -i '/shell #{@key_id}\"/d' #{auth_file}"
+    cmd = "sed '/shell #{@key_id}\"/d' #{auth_file} > #{auth_file}.$$ && /bin/mv #{auth_file}.$$ #{auth_file}"
     system(cmd)
   end
 end


### PR DESCRIPTION
Introduces POSIX compatibility for `sed` command usage. The change avoids the `-i` flag that has different syntax in BSD and thus was causing the issue #8.
