### PR TITLE
propably better ssh-key id finding in ARGV

### DIFF
--- a/lib/gitlab_shell.rb
+++ b/lib/gitlab_shell.rb
@@ -6,8 +6,6 @@ class GitlabShell
   attr_accessor :key_id, :repo_name, :git_cmd, :repos_path, :repo_name
 
   def initialize
-    puts "---"
-    puts ARGV
     @key_id = /key-[0-9]+/.match(ARGV.join).to_s
     @origin_cmd = ENV['SSH_ORIGINAL_COMMAND']
     @repos_path = GitlabConfig.new.repos_path


### PR DESCRIPTION
I have issue with fresh instalation of gitlab on debian squeze

gitlab-shell cannot verify my ssh-key on issuing git commands

variable ARGV have inside some random parameters.
I dont find from where this '-c' come.

this ends with wrong call to gitlab api

```
/api/v3/internal/allowed?key_id=-c&action=git-upload-pack&ref=_any&project=user/repo
```

so i replace simple ARGV.shift with regex

content of ARGV on my installation

```
-c
/home/git/gitlab-shell/bin/gitlab-shell key-4
```
