### PR TITLE
Add ca_file/ca_path configuration options.

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -7,6 +7,8 @@ gitlab_url: "http://localhost/"
 http_settings:
 #  user: someone
 #  password: somepass
+#  ca_file: /etc/ssl/cert.pem
+#  ca_path: /etc/pki/tls/certs
   self_signed_cert: false
 
 # Repositories path


### PR DESCRIPTION
gitlab-shell should provide a way to choose the correct certificates instead of getting users to set self_signed_cert to bypass verification.
