### PR TITLE
Support for a custom gitlab-shell script in config

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -37,3 +37,7 @@ log_level: INFO
 # Set to true to see real usernames in the logs instead of key ids, which is easier to follow, but
 # incurs an extra API call on every gitlab-shell command.
 audit_usernames: false
+
+# Overwrite Gitlab-Shell wrapper binary to a custom script. This can be used to wrap gitlab-shell with a custom ruby environment (ie. rvm). 
+# The default value is "ROOT_DIR/gitlab-shell/bin/gitlab-shell"
+# gitlab_shell_bin: "/home/git/gitlab-shell/bin/gitlab-shell-custom_rubyenv"

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -19,6 +19,10 @@ class GitlabConfig
     @config['gitlab_url'] ||= "http://localhost/"
   end
 
+  def gitlab_shell_bin
+    @config['gitlab_shell_bin'] || "#{ROOT_PATH}/bin/gitlab-shell"
+  end
+
   def http_settings
     @config['http_settings'] ||= {}
   end

--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -11,6 +11,7 @@ class GitlabKeys
     @key_id = ARGV.shift
     @key = ARGV.shift
     @auth_file = GitlabConfig.new.auth_file
+    @gitlab_shell_bin = GitlabConfig.new.gitlab_shell_bin
   end
 
   def exec
@@ -28,7 +29,7 @@ class GitlabKeys
 
   def add_key
     $logger.info "Adding key #{@key_id} => #{@key.inspect}"
-    cmd = "command=\"#{ROOT_PATH}/bin/gitlab-shell #{@key_id}\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty #{@key}"
+    cmd = "command=\"#{@gitlab_shell_bin} #{@key_id}\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty #{@key}"
     cmd = "echo \'#{cmd}\' >> #{auth_file}"
     system(cmd)
   end


### PR DESCRIPTION
Overwrite script gitlab-shell script location in config.yml.
Possible uses:
- Setup a custom Ruby Environment and wrap gitlab shell script
- Add some additional checks

I'm aware of issue https://github.com/gitlabhq/gitlab-shell/issues/12 . But the suggested solution namely setting 

```
PermitUserEnvironment yes
```

in the SSH config will introduce additional problems which we don't want:
- We increase the risk for an incursion. 
- It makes the management of a machine running gitlab a nightmare. Since the sshd config needs to be managed somehow. 

Hence I suggest the following solution which allows overwriting the gitlab-shell binary with a custom script defined in the gitlab-shell config:
- The config can be deployed with puppet.
- The binary can contain whichever ruby version settings want.
- The default config will still use the default script.
- The solution is gitlab-shell version agnostic: Update gitlab-shell, keep the edited script.

An alternative would be to just overwrite gitlab-shell script and edit with every update. Which makes upgrading a pain.
