### PR TITLE
bsd sed requires an argument for -i option.

### DIFF
--- a/lib/gitlab_keys.rb
+++ b/lib/gitlab_keys.rb
@@ -35,7 +35,7 @@ class GitlabKeys
 
   def rm_key
     $logger.info "Removing key #{@key_id}"
-    cmd = "sed -i '/shell #{@key_id}\"/d' #{auth_file}"
+    cmd = "sed -i'' '/shell #{@key_id}\"/d' #{auth_file}"
     system(cmd)
   end
 end

--- a/spec/gitlab_keys_spec.rb
+++ b/spec/gitlab_keys_spec.rb
@@ -33,7 +33,7 @@ describe GitlabKeys do
     let(:gitlab_keys) { build_gitlab_keys('rm-key', 'key-741', 'ssh-rsa AAAAB3NzaDAxx2E') }
 
     it "should receive valid cmd" do
-      valid_cmd = "sed -i '/shell key-741\"/d' #{GitlabConfig.new.auth_file}"
+      valid_cmd = "sed -i'' '/shell key-741\"/d' #{GitlabConfig.new.auth_file}"
       gitlab_keys.should_receive(:system).with(valid_cmd)
       gitlab_keys.send :rm_key
     end


### PR DESCRIPTION
BSD sed requires an argument for '-i' option while GNU sed can omit it.
For supporting both versions, just put empty string as argument.
Thank you.
