### PR TITLE
Utilize full branch name when checking permissions.

### DIFF
--- a/lib/gitlab_update.rb
+++ b/lib/gitlab_update.rb
@@ -15,7 +15,7 @@ class GitlabUpdate
 
     @key_id = key_id
     @refname = refname
-    @branch_name = /refs\/heads\/([\w\.-]+)/.match(refname).to_a.last
+    @branch_name = /refs\/heads\/(.+)/.match(refname).to_a.last
 
     @oldrev  = ARGV[1]
     @newrev  = ARGV[2]

--- a/spec/gitlab_update_spec.rb
+++ b/spec/gitlab_update_spec.rb
@@ -1,0 +1,38 @@
+require_relative 'spec_helper'
+require_relative '../lib/gitlab_update'
+
+describe GitlabUpdate do
+  describe :exec do
+    let(:repo_name)   { 'myproject' }
+    let(:key_id)      { 'key-123' }
+    let(:branch_name) { '/refs/heads/master' }
+    let(:api) { double(GitlabNet) }
+    subject do
+      described_class.new(repo_name, key_id, branch_name).tap do |o|
+        o.stub(:api => api)
+      end
+    end
+
+    context "when the user is not allowed to push to a protected branch" do
+      before { api.stub(:allowed? => false) }
+      it "should deny pushing" do
+        expect { subject.exec }.to terminate.with_code(1)
+      end
+    end
+
+    context "when the user is allowed to push to a protected branch" do
+      before { api.stub(:allowed? => true) }
+      it "should allow pushing" do
+        expect { subject.exec }.to terminate
+      end
+    end
+
+    context "when the branch name contains a slash" do
+      let(:branch_name) { '/refs/heads/users/bob/master' }
+      it "should check the correct branch name" do
+        api.should_receive(:allowed?).with('git-receive-pack', repo_name, key_id, 'users/bob/master').and_return(true)
+        expect { subject.exec }.to terminate
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,45 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.configure_rspec_metadata!
 end
+
+module ExitCodeMatchers
+  extend RSpec::Matchers::DSL
+
+  matcher :terminate do
+    actual = nil
+
+    match do |block|
+      begin
+        block.call
+      rescue SystemExit => e
+        actual = e.status
+      end
+      actual and actual == status_code
+    end
+
+    chain :with_code do |status_code|
+      @status_code = status_code
+    end
+
+    failure_message_for_should do |block|
+      "expected block to call exit(#{status_code}) but exit" +
+        (actual.nil? ? " not called" : "(#{actual}) was called")
+    end
+
+    failure_message_for_should_not do |block|
+      "expected block not to call exit(#{status_code})"
+    end
+
+    description do
+      "expect block to call exit(#{status_code})"
+    end
+
+    def status_code
+      @status_code ||= 0
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include ExitCodeMatchers
+end


### PR DESCRIPTION
fixes gitlabhq/gitlabhq#3775

ExitCodeMatchers from https://gist.github.com/stevenharman/2355172
