### PR TITLE
Add optional repo path, remove reference to gitolite repo

### DIFF
--- a/support/truncate_repositories.sh
+++ b/support/truncate_repositories.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
-home_dir="/home/git"
+# $1 is an optional argument specifying the location of the repositories directory.
+# Defaults to /home/git/repositories if not provided
+
+
+home_dir="/home/git/repositories"
+src=${1:-"$home_dir"}
 
 echo "Danger!!! Data Loss"
 while true; do
-  read -p "Do you wish to delete all directories (except gitolite-admin.git) from $home_dir/repositories/ (y/n) ?:  " yn
+  read -p "Do you wish to delete all directories from $home_dir/ (y/n) ?:  " yn
   case $yn in
-    [Yy]* ) sh -c "find $home_dir/repositories/. -maxdepth 1  -not -name 'gitolite-admin.git' -not -name '.' | xargs rm -rf"; break;;
+    [Yy]* ) sh -c "find $home_dir/. -maxdepth 1 -not -name '.' | xargs rm -rf"; break;;
     [Nn]* ) exit;;
     * ) echo "Please answer yes or no.";;
   esac


### PR DESCRIPTION
`truncate_repositories` uses a hardcoded path to the base path of all repos. I added an optional parameter for non-default installations.

Additionally I removed the exception for removing the gitolite-repository, since it's deprecated.
