### PR TITLE
Replace build in home folder with environment

### DIFF
--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -7,12 +7,16 @@ class GitlabConfig
     @config = YAML.load_file(File.join(ROOT_PATH, 'config.yml'))
   end
 
+  def home
+    ENV['HOME']
+  end
+
   def repos_path
-    @config['repos_path'] ||= "/home/git/repositories"
+    @config['repos_path'] ||= File.join(home, "repositories")
   end
 
   def auth_file
-    @config['auth_file'] ||= "/home/git/.ssh/authorized_keys"
+    @config['auth_file'] ||= File.join(home, ".ssh/authorized_keys")
   end
 
   def gitlab_url


### PR DESCRIPTION
You can't ever assume that user's home is /home/$USERNAME or /home/git

Preferable is to assume that user running gitlab-shell has repositories in his home (get from the environment).

I didn't test this yet with real system, but ./bin/check reports correct paths.
