### PR TITLE
Fix absolute path requirement.

### DIFF
--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -9,6 +9,7 @@ class GitlabConfig
 
   def repos_path
     @config['repos_path'] ||= "/home/git/repositories"
+    @config['repos_path'] = File.realpath(@config['repos_path'])
   end
 
   def auth_file


### PR DESCRIPTION
I do not know why anything in the code would need absolute path for repositories, but this should fix it.

Drawback is that if directory is missing exception is thrown from realpath()
