### PR TITLE
More detailed warning about symlinks in repos_path

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -12,7 +12,9 @@ http_settings:
   self_signed_cert: false
 
 # Repositories path
-# REPOS_PATH MUST NOT BE A SYMLINK!!!
+# Give the canonicalized absolute pathname,
+# REPOS_PATH MUST NOT CONTAIN ANY SYMLINK!!!
+# Check twice that none of the components is a symlink, including "/home".
 repos_path: "/home/git/repositories"
 
 # File used as authorized_keys for gitlab user


### PR DESCRIPTION
The warning about the repository path not being a symlink is ambiguous. I understood that the final component must not be a symlink and ran into issue #7. This pull request resolves the ambiguity and includes a hint to check whether  "/home" is a symlink, which one may easily forget about.
