### PR TITLE
[RFC] Add command to synchronize an imported repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Import repo
 
     ./bin/gitlab-projects import-project randx/six.git https://github.com/randx/six.git
 
+Sync imported repo
+
+    ./bin/gitlab-projects sync-imported-repository randx/six.git https://github.com/randx/six.git master master
+
 Fork repo
 
     ./bin/gitlab-projects fork-project gitlab/gitlab-ci.git randx

--- a/lib/gitlab_projects.rb
+++ b/lib/gitlab_projects.rb
@@ -34,6 +34,7 @@ class GitlabProjects
     when 'rm-project';  rm_project
     when 'mv-project';  mv_project
     when 'import-project'; import_project
+    when 'sync-imported-repository'; sync_imported_repository
     when 'fork-project'; fork_project
     when 'update-head';  update_head
     else
@@ -93,6 +94,20 @@ class GitlabProjects
     @source = ARGV.shift
     $logger.info "Importing project #{@project_name} from <#{@source}> to <#{full_path}>."
     cmd = "cd #{repos_path} && git clone --bare #{@source} #{project_name} && #{create_hooks_cmd}"
+    system(cmd)
+  end
+
+  # Fetch new commits and tags from a given branch of an imported project
+  # URL must be publicly cloneable
+  def sync_imported_repository
+    @source = ARGV.shift
+    @source_branch = ARGV.shift
+    @dest_branch = ARGV.shift
+
+    $logger.info "Update imported project #{@project_name} from <#{@source}:#{@source_branch}> to <#{full_path}:#{@dest_branch}>."
+    cmd = "cd #{repos_path}/#{project_name} && git fetch #{@source} #{@source_branch}:#{@dest_branch}"
+
+    # Please note that this command doesn't fire a GitPushService
     system(cmd)
   end
 

--- a/spec/gitlab_projects_spec.rb
+++ b/spec/gitlab_projects_spec.rb
@@ -209,6 +209,29 @@ describe GitlabProjects do
     end
   end
 
+  describe :update_imported_project do
+    let(:gl_projects) { build_gitlab_projects('import-project', repo_name, 'https://github.com/randx/six.git') }
+
+    it "should update an existing repo (master branch)" do
+      gl_projects.exec
+
+      origin_count = IO.popen("cd #{tmp_repo_path} && git log --oneline | wc -l") { |f| f.gets }.to_i
+      system("cd #{tmp_repo_path} && git update-ref HEAD HEAD~2")
+      postreset_count = IO.popen("cd #{tmp_repo_path} && git log --oneline | wc -l") { |f| f.gets }.to_i
+
+      (origin_count - postreset_count).should == 3
+
+      build_gitlab_projects('sync-imported-repository', repo_name, 'https://github.com/randx/six.git', 'master', 'master').exec
+
+      afterupdate_count = IO.popen("cd #{tmp_repo_path} && git log --oneline | wc -l") { |f| f.gets }.to_i
+      afterupdate_count.should == origin_count
+    end
+
+    it "should update an existing repo (other branch)"
+
+    it "should update an existing repo (different branches)"
+  end
+
   describe :fork_project do
     let(:source_repo_name) { File.join('source-namespace', repo_name) }
     let(:dest_repo) { File.join(tmp_repos_path, 'forked-to-namespace', repo_name) }


### PR DESCRIPTION
NOTE: This PR is not to be merged, but I just need to get some feedback.

This patch adds a command (that needs to be refined) to synchronize an imported repository with its origin.
It accepts also a different remote and source/dest branches (e.g., origin:branchA to local:branchB).

The main point missing (besides more tests) is that we need to trigger something like a GitPushService...
