### PR TITLE
fixed issue#5408(from gitlabhq/gitlabhq) update_head

### DIFF
--- a/lib/gitlab_projects.rb
+++ b/lib/gitlab_projects.rb
@@ -166,15 +166,12 @@ class GitlabProjects
       return false
     end
 
-    unless File.exists?(File.join(full_path, 'refs/heads', new_head))
-      $logger.error "update-head failed: specified branch does not exist in ref/heads."
+    unless (system("cd #{full_path} && git show-ref --heads #{new_head}"))
+      $logger.error "update-head failed: error while looking for branch ref in project #{project_name}."
       return false
     end
 
-    File.open(File.join(full_path, 'HEAD'), 'w') do |f|
-      f.write("ref: refs/heads/#{new_head}")
-    end
-
+    system("cd #{full_path} && git symbolic-ref HEAD refs/heads/#{new_head}")
     $logger.info "Update head in project #{project_name} to <#{new_head}>."
     true
   end

--- a/spec/gitlab_projects_spec.rb
+++ b/spec/gitlab_projects_spec.rb
@@ -178,8 +178,11 @@ describe GitlabProjects do
 
     before do
       FileUtils.mkdir_p(tmp_repo_path)
-      system("git init --bare #{tmp_repo_path}")
-      system("touch #{tmp_repo_path}/refs/heads/stable")
+      system("git init --bare #{tmp_repo_path} && cd #{tmp_repo_path} && touch test && git hash-object -w test")
+      tree_init_sha = `cd #{tmp_repo_path} && git write-tree --missing-ok`
+      commit_sha = `cd #{tmp_repo_path} && git commit-tree -m "test" #{tree_init_sha}`
+      system("cd #{tmp_repo_path} && git update-ref refs/heads/master #{commit_sha}")
+      system("cd #{tmp_repo_path} && git branch stable")
       File.read(File.join(tmp_repo_path, 'HEAD')).strip.should == 'ref: refs/heads/master'
     end
 


### PR DESCRIPTION
Please have a look at discussion this issue https://github.com/gitlabhq/gitlabhq/issues/5408 in **gitlabhq/gitlabhq**.

Although this fix is enough for the part which gitlab_shell is doing, but after changing the default branch in project settings if you directly goto **Files** or **Commits**, the selected branch in dropdown is still the old one. So if you goto project home once and come back to **Files** or **Commits** then selected branch in dropdown is updated to default one. And I think this has to do something with updating project model about the default_branch.

Here Line#169..172 checks the output of **git show-ref** if it is empty or not, and thus validates the availability of the supplied ref.

My apologies in advance if there is some mistake, as I never programmed/touched ruby before and these few lines are my first attempt. yesterday I submitted another PR for same thing but I didn't validate the tests, this time I ran the tests, it was all ok.
