### PR TITLE
Allows mv_project to create parent directories if required

### DIFF
--- a/lib/gitlab_projects.rb
+++ b/lib/gitlab_projects.rb
@@ -115,6 +115,7 @@ class GitlabProjects
     end
 
     new_full_path = File.join(repos_path, new_path)
+    parent_path = File.join(repos_path, new_path[0...-1])
 
     # verify that the source repo exists
     unless File.exists?(full_path)
@@ -127,6 +128,9 @@ class GitlabProjects
       $logger.error "mv-project failed: destination path <#{new_full_path}> already exists."
       return false
     end
+
+    # Make the parent path if necessary
+    FileUtils.mkdir_p(parent_path)
 
     $logger.info "Moving project #{@project_name} from <#{full_path}> to <#{new_full_path}>."
     FileUtils.mv(full_path, new_full_path)

--- a/spec/gitlab_projects_spec.rb
+++ b/spec/gitlab_projects_spec.rb
@@ -116,6 +116,7 @@ describe GitlabProjects do
   describe :mv_project do
     let(:gl_projects) { build_gitlab_projects('mv-project', repo_name, 'repo.git') }
     let(:new_repo_path) { File.join(tmp_repos_path, 'repo.git') }
+    let(:nonexistent_parent_path) { File.join(tmp_repos_path, 'nonexistent', 'repo.git') } 
 
     before do
       FileUtils.mkdir_p(tmp_repo_path)
@@ -127,6 +128,14 @@ describe GitlabProjects do
       File.exists?(tmp_repo_path).should be_false
       File.exists?(new_repo_path).should be_true
     end
+
+    it "should move a repo directory even if the namespace directory does not exist" do
+        File.exists?(tmp_repo_path).should be_true
+        build_gitlab_projects('mv-project', repo_name, 'nonexistent/repo.git').exec
+        File.exists?(tmp_repo_path).should be_false
+        File.exists?(nonexistent_parent_path).should be_true
+    end
+
 
     it "should fail if no destination path is provided" do
       incomplete = build_gitlab_projects('mv-project', repo_name)


### PR DESCRIPTION
This is useful when performing the 
'sudo -u git -H bundle exec rake migrate_global_projects RAILS_ENV=production'
step at 
https://github.com/gitlabhq/gitlabhq/blob/master/doc/update/5.4-to-6.0.md
