### PR TITLE
Check for redis-cli binary

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -18,7 +18,7 @@ end
 puts "\nCheck directories and files: "
 
 config = GitlabConfig.new
-dirs = [config.repos_path, config.auth_file]
+dirs = [config.repos_path, config.auth_file, config.redis['bin']]
 
 dirs.each do |dir|
   print "\t#{dir}: "


### PR DESCRIPTION
Fixes #84. Credit to @dbck.

The gitlab-shell check script should validate the redis-cli binary path provided in config.yml. None of the existing checks seem to fail, but the user ends up with odd results like no commit messages showing up in the activity feed (while other things do, such as issues or comments).
