### PR TITLE
Display appropriate error message on config error

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -21,6 +21,7 @@ config = GitlabConfig.new
 dirs = [config.repos_path, config.auth_file, config.redis['bin']]
 
 dirs.each do |dir|
+  abort("ERROR: missing option in config.yml") unless dir
   print "\t#{dir}: "
   if File.exists?(dir)
     print 'OK'


### PR DESCRIPTION
When a key is missing in configuration, e.g. the redis key, then the dir is `nil` which leads to a confusion exception traceback. This prints an error and aborts checks. It's also referenced here: https://github.com/gitlabhq/gitlabhq/issues/5603
