### PR TITLE
Skip proxy look up from environment

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -10,6 +10,7 @@ http_settings:
 #  ca_file: /etc/ssl/cert.pem
 #  ca_path: /etc/pki/tls/certs
   self_signed_cert: false
+  proxy_from_env: false
 
 # Repositories path
 # Give the canonicalized absolute pathname,

--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -43,7 +43,11 @@ class GitlabNet
     $logger.debug "Performing GET #{url}"
 
     url = URI.parse(url)
-    http = Net::HTTP.new(url.host, url.port)
+    if config.http_settings['proxy_from_env']
+      http = Net::HTTP.new(url.host, url.port)
+    else
+      http = Net::HTTP.new(url.host, url.port, nil)
+    end
 
     if URI::HTTPS === url
       http.use_ssl = true


### PR DESCRIPTION
Fixes #116
Adds configuration option to skip proxy look up from environment.
Works with Ruby 1.9.3 as well as 2.0.0.
