### PR TITLE
Fixing error with unallowed commands

### DIFF
--- a/lib/gitlab_shell.rb
+++ b/lib/gitlab_shell.rb
@@ -42,7 +42,7 @@ class GitlabShell
   def parse_cmd
     args = Shellwords.shellwords(@origin_cmd)
     @git_cmd = args[0]
-    @repo_name = escape_path(args[1])
+    @repo_name = args[1].nil? ? "" : escape_path(args[1])
   end
 
   def git_cmds

--- a/spec/gitlab_shell_spec.rb
+++ b/spec/gitlab_shell_spec.rb
@@ -118,6 +118,24 @@ describe GitlabShell do
       end
     end
 
+    context 'one word arbitrary command' do
+      before { ssh_cmd 'one-word-arbitrary-command' }
+      after { subject.exec }
+
+      it "should not process the command" do
+        subject.should_not_receive(:process_cmd)
+      end
+
+      it "should not execute the command" do
+        subject.should_not_receive(:exec_cmd)
+      end
+
+      it "should log the attempt" do
+        message = "gitlab-shell: Attempt to execute disallowed command <one-word-arbitrary-command> by user with key #{key_id}."
+        $logger.should_receive(:warn).with(message)
+      end
+    end
+
     context 'no command' do
       before { ssh_cmd nil }
       after { subject.exec }


### PR DESCRIPTION
When running this to test the ssh connectivity, I found this bug:

```
-> % ssh git@gitlab ls
/home/git/gitlab-shell/lib/gitlab_shell.rb:102:in `join': can't convert nil into String (TypeError)
    from /home/git/gitlab-shell/lib/gitlab_shell.rb:102:in `escape_path'
    from /home/git/gitlab-shell/lib/gitlab_shell.rb:57:in `parse_cmd'
    from /home/git/gitlab-shell/lib/gitlab_shell.rb:22:in `exec'
    from /home/git/gitlab-shell/bin/gitlab-shell:16:in `<main>'
```

The expected behaviour would be :

```
-> % ssh git@gitlab ls
Not allowed command
```

Excuse me for my ruby style, I am not used to this language.
