### PR TITLE
gitlab_url should not end with a slash.

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,8 +1,8 @@
 # GitLab user. git by default
 user: git
 
-# Url to gitlab instance. Used for api calls. Should end with a slash.
-gitlab_url: "http://localhost/"
+# Url to gitlab instance. Used for api calls. Should NOT end with a slash.
+gitlab_url: "http://localhost"
 
 http_settings:
 #  user: someone


### PR DESCRIPTION
The gitlab_url should not end with a slash. It makes two slashes in the URL.

Debug log from gitlab-shell:
D, [2013-12-30T21:41:27.415409 #27249] DEBUG -- : Performing GET http://gitlab//api/v3/internal/allowed?key_id=1&action=git-receive-pack&ref=_any&project=testproj

The parameter is used in this line and it adds the slash:
https://github.com/gitlabhq/gitlab-shell/blob/master/lib/gitlab_net.rb#L39
