### PR TITLE
Add check for non-existant hooks dir, and create if missing

### DIFF
--- a/lib/gitlab_projects.rb
+++ b/lib/gitlab_projects.rb
@@ -17,6 +17,7 @@ class GitlabProjects
   attr_reader :full_path
 
   def self.create_hooks(path)
+    FileUtils.mkdir(File.join(path, 'hooks'), mode: 0770) if !File.directory?(File.join(path, 'hooks'))
     hook = File.join(path, 'hooks', 'update')
     File.delete(hook) if File.exists?(hook)
     File.symlink(File.join(ROOT_PATH, 'hooks', 'update'), hook)


### PR DESCRIPTION
Let me know if I need to make any changes to conform to some contributing standards, but in our environment we were having issues creating forks for some projects and this one line of code fixed it.

The /hooks/ dir was missing so trying to symlink to /hooks/update was throwing and error.

It seems (to me) that it would be a harmless change for the most part.
