### PR TITLE
added support for redis password

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -25,6 +25,7 @@ redis:
   bin: /usr/bin/redis-cli
   host: 127.0.0.1
   port: 6379
+  # pass: redispass # Allows you to specify the password for Redis
   # socket: /tmp/redis.socket # Only define this if you want to use sockets
   namespace: resque:gitlab
 

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -53,7 +53,11 @@ class GitlabConfig
       if redis.has_key?("socket")
         %W(#{redis['bin']} -s #{redis['socket']})
       else
-        %W(#{redis['bin']} -h #{redis['host']} -p #{redis['port']})
+        if redis.has_key?("pass")
+          %W(#{redis['bin']} -h #{redis['host']} -p #{redis['port']} -a #{redis['pass']})
+        else
+          %W(#{redis['bin']} -h #{redis['host']} -p #{redis['port']})
+        end
       end
     end
   end


### PR DESCRIPTION
gitlabhq has support for password protected redis, but I needed it for gitlab-shell as well
