### PR TITLE
GitlabUpdate: use stripped path for repo_name

### DIFF
--- a/lib/gitlab_update.rb
+++ b/lib/gitlab_update.rb
@@ -9,7 +9,7 @@ class GitlabUpdate
     @config = GitlabConfig.new
 
     @repo_path = repo_path.strip
-    @repo_name = repo_path
+    @repo_name = @repo_path
     @repo_name.gsub!(config.repos_path.to_s, "")
     @repo_name.gsub!(/\.git$/, "")
     @repo_name.gsub!(/^\//, "")


### PR DESCRIPTION
I noticed an issue where a newline character was at the end of the repo_path, and as a result the api.allowed call was failing (note the %0A at the end of the project name):

> D, [2014-06-16T11:16:18.293419 #6236] DEBUG -- : Performing GET http://localhost//api/v3/internal/allowed?action=git-receive-pack&ref=test&project=test%2Ftest%0A&forced_push=false&oldrev=0000000000000000000000000000000000000000&newrev=242f697a698b09cefd12c2f7784ee8877542e777&key_id=9

Changing to use the already-stripped repo_path instead solved the problem for me. 
