### PR TITLE
Fix spec for GitlabConfig.gitlab_url.

### DIFF
--- a/spec/gitlab_config_spec.rb
+++ b/spec/gitlab_config_spec.rb
@@ -21,10 +21,12 @@ describe GitlabConfig do
   end
 
   describe :gitlab_url do
+    let(:url) { 'http://test.com' }
     subject { config.gitlab_url }
+    before { config.send(:config)['gitlab_url'] = url }
 
     it { should_not be_empty }
-    it { should eq('http://localhost:8080/') }
+    it { should eq(url) }
   end
 
   describe :audit_usernames do


### PR DESCRIPTION
It makes the `gitlab_url` spec independent from the content of `config.yml`.
