### PR TITLE
Delete file or symlink in create_hooks

### DIFF
--- a/lib/gitlab_projects.rb
+++ b/lib/gitlab_projects.rb
@@ -19,7 +19,7 @@ class GitlabProjects
 
   def self.create_hooks(path)
     hook = File.join(path, 'hooks', 'update')
-    File.delete(hook) if File.exists?(hook)
+    File.delete(hook) if File.exists?(hook) || File.symlink?(hook)
     File.symlink(File.join(ROOT_PATH, 'hooks', 'update'), hook)
   end
 


### PR DESCRIPTION
Had my bare repositories copied from another server, where an earlier version of gitlab was used, a version running gitolite, and after repo import the rake task testing the update hooks failed, because the symlink was there, as File.exists doesn't cover them.

At least the following problems occurred inside gitlab:
- New branches not shown in dropdowns, all branches etc
- Deleted branches kept appearing and erroring tried to access them
- No push/merge/branch deletion events in any timelines
- Api calls to "invisible" branches resulted in 500 errors
