### PR TITLE
Match .log* instead of .log.* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 config.yml
 tmp/*
 *.log
-/*.log.*
+/*.log*
 authorized_keys.lock


### PR DESCRIPTION
Something like gitlab-shell.log-20140626.gz will not be caught by the
original pattern match since '.' is taken as a literal character.
