### PR TITLE
remove unnesesary option

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -11,8 +11,6 @@ gitlab_url: "http://localhost:8080/"
 http_settings:
 #  user: someone
 #  password: somepass
-#  ca_file: /etc/ssl/cert.pem
-#  ca_path: /etc/pki/tls/certs
   self_signed_cert: false
 
 # Repositories path

--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -57,7 +57,6 @@ class GitlabNet
     Net::HTTP.new(url.host, url.port).tap do |http|
       if URI::HTTPS === url
         http.use_ssl = true
-        http.cert_store = cert_store
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE if config.http_settings['self_signed_cert']
       end
     end
@@ -84,18 +83,5 @@ class GitlabNet
       end
     end
   end
-
-  def cert_store
-    @cert_store ||= OpenSSL::X509::Store.new.tap { |store|
-      store.set_default_paths
-
-      if ca_file = config.http_settings['ca_file']
-        store.add_file(ca_file)
-      end
-
-      if ca_path = config.http_settings['ca_path']
-        store.add_path(ca_path)
-      end
-    }
-  end
 end
+

--- a/spec/gitlab_net_spec.rb
+++ b/spec/gitlab_net_spec.rb
@@ -79,7 +79,6 @@ describe GitlabNet, vcr: true do
   describe :http_client_for do
     subject { gitlab_net.send :http_client_for, URI('https://localhost/') }
     before do
-      gitlab_net.stub! :cert_store
       gitlab_net.send(:config).http_settings.stub(:[]).with('self_signed_cert') { true }
     end
 
@@ -105,34 +104,5 @@ describe GitlabNet, vcr: true do
 
     it { should_not be_nil }
   end
-
-  describe :cert_store do
-    let(:store) do
-      double(OpenSSL::X509::Store).tap do |store|
-        OpenSSL::X509::Store.stub(:new) { store }
-      end
-    end
-
-    before :each do
-      store.should_receive(:set_default_paths).once
-    end
-
-    after do
-      gitlab_net.send :cert_store
-    end
-
-    it "calls add_file with http_settings['ca_file']" do
-      gitlab_net.send(:config).http_settings.stub(:[]).with('ca_file') { 'test_file' }
-      gitlab_net.send(:config).http_settings.stub(:[]).with('ca_path') { nil }
-      store.should_receive(:add_file).with('test_file')
-      store.should_not_receive(:add_path)
-    end
-
-    it "calls add_path with http_settings['ca_path']" do
-      gitlab_net.send(:config).http_settings.stub(:[]).with('ca_file') { nil }
-      gitlab_net.send(:config).http_settings.stub(:[]).with('ca_path') { 'test_path' }
-      store.should_not_receive(:add_file)
-      store.should_receive(:add_path).with('test_path')
-    end
-  end
 end
+


### PR DESCRIPTION
Http client no need to know about ssl key

1) it seems insecure to set 775 for key
2) less config options
3) less code

Maybe I'm wrong.
