### PR TITLE
Add an option to communicate with GitLab via UNIX domain socket

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -15,6 +15,10 @@ http_settings:
 #  ca_path: /etc/pki/tls/certs
   self_signed_cert: false
 
+# Alternatively to communicating via TCP sockets, the Unix domain socket
+# can be used. Useful if HTTP is only accessible with a client certificate.
+# unix_socket: "/home/git/gitlab/tmp/sockets/gitlab.socket"
+
 # Repositories path
 # Give the canonicalized absolute pathname,
 # REPOS_PATH MUST NOT CONTAIN ANY SYMLINK!!!

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -43,6 +43,10 @@ class GitlabConfig
     @config['audit_usernames'] ||= false
   end
 
+  def unix_socket
+    @config['unix_socket']
+  end
+
   # Build redis command to write update event in gitlab queue
   def redis_command
     if redis.empty?


### PR DESCRIPTION
This is useful when access via HTTP is only allowed using an SSL client certificate.