### PR TITLE
HOME Environment can be necessary for gem

### DIFF
--- a/lib/gitlab_shell.rb
+++ b/lib/gitlab_shell.rb
@@ -61,7 +61,7 @@ class GitlabShell
 
   # This method is not covered by Rspec because it ends the current Ruby process.
   def exec_cmd(*args)
-    Kernel::exec({'PATH' => ENV['PATH'], 'LD_LIBRARY_PATH' => ENV['LD_LIBRARY_PATH'], 'GL_ID' => ENV['GL_ID']}, *args, unsetenv_others: true)
+    Kernel::exec({'PATH' => ENV['PATH'], 'LD_LIBRARY_PATH' => ENV['LD_LIBRARY_PATH'], 'GL_ID' => ENV['GL_ID'], 'HOME' => ENV['HOME']}, *args, unsetenv_others: true)
   end
 
   def api


### PR DESCRIPTION
Setup: CentOS 6, gitlab 7.1.1, ruby 1.9.3, gem 1.8.23

git push resulted in:

```
remote: /opt/rh/ruby193/root/usr/share/rubygems/rubygems/custom_require.rb:36:in `require': cannot load such file -- json (LoadError)
remote:     from /opt/rh/ruby193/root/usr/share/rubygems/rubygems/custom_require.rb:36:in `require'
remote:     from /home/git/gitlab-shell/lib/gitlab_net.rb:3:in `<top (required)>'
remote:     from /home/git/gitlab-shell/lib/gitlab_update.rb:3:in `require_relative'
remote:     from /home/git/gitlab-shell/lib/gitlab_update.rb:3:in `<top (required)>'
remote:     from hooks/update:11:in `require_relative'
remote:     from hooks/update:11:in `<main>'
remote: error: hook declined to update refs/heads/master
```

`.ssh/environment` contains `PATH=/home/git/gitlab/vendor/bundle/ruby/1.9.1/bin...`

gem seems to need `HOME` environment variable:

```
>unset HOME
>gem environment
    ERROR:  While executing gem ... (ArgumentError)
    couldn't find HOME environment -- expanding `~'
```
