### PR TITLE
Let hound prefer single-quote strings

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true


### PR DESCRIPTION
GitLab prefers single quote strings.
