### PR TITLE
fixing broken custom pre-receive calls

### DIFF
--- a/lib/gitlab_access.rb
+++ b/lib/gitlab_access.rb
@@ -18,7 +18,7 @@ class GitlabAccess
 
   def exec
     if api.allowed?('git-receive-pack', @repo_name, @actor, @changes)
-      return 1
+      return true
     else
       # reset GL_ID env since we stop git push here
       ENV['GL_ID'] = nil


### PR DESCRIPTION
The gitlab pre-receive hook expects the call to exec to return 1
when a user has access. Doing an exit 0 effectively ended the
thread. No code would be executed after the call to exec.

This changes fixes the problem for the pre-receive hooks but you want
to check that GitlabAccess.exec is not used elsewhere. A quick
grep of the code seems to indicate this is not the case
