### PR TITLE
Custom post-receive hooks can't be called

### DIFF
--- a/lib/gitlab_post_receive.rb
+++ b/lib/gitlab_post_receive.rb
@@ -27,6 +27,6 @@ class GitlabPostReceive
       puts "GitLab: An unexpected error occurred (redis-cli returned #{$?.exitstatus})."
       exit 1
     end
-    return true
+    true
   end
 end


### PR DESCRIPTION
Similar to #192 and not yet taken into account in #190

The update_redis method was missing a "return true" when the
operation is succesful.  Without it, any custom post-receive
hooks that come after the call to GitlabPostReceive.exec.

I tested this change in a local copy and it fixes the issue.
