### PR TITLE
check email feature

### DIFF
--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -25,7 +25,7 @@ class GitlabNet
 
     url = "#{host}/allowed"
     resp = post(url, params)
-
+    puts resp.body unless ['true','false'].include?(resp.body)
     !!(resp.code == '200' && resp.body == 'true')
   end
 


### PR DESCRIPTION
That change allow to display error messages provided by API server
That is a part of email check feature https://github.com/gitlabhq/gitlabhq/pull/8242/

When user is trying to do the "PUSH" operation, the Gitlab server perform the check of user's e-mail address within the existing Gitlab user database.
If user's e-mail does not exist, then Gitlab does not allow to "PUSH" and display the corresponding message "User is not allowed to PUSH due to invalid e-mail address, please, use your registered e-mail address".
To make error message displayed corresponding pull request to the repository gitlab-shell has been created
