### PR TITLE
alwayss output stdout/stderr messages from custom hooks

### DIFF
--- a/lib/gitlab_custom_hook.rb
+++ b/lib/gitlab_custom_hook.rb
@@ -54,8 +54,8 @@ class GitlabCustomHook
       # only output stdut_stderr if scripts doesn't return 0
       unless wait_thr.value == 0
         exit_status = false
-        stdout_stderr.each_line { |line| puts line }
       end
+      stdout_stderr.each_line { |line| puts line }
     end
 
     exit_status


### PR DESCRIPTION
@dblessing, here's a small after-thought correction to the custom hooks patch that passed me by. git actually always outputs whatever messages the custom hooks send. I had wrongly only printed those messages if there was an error. This patch restores the expected behavior.  Everything now works as prior to the introduction of the symlinked hooks directory.
