### PR TITLE
remove slash in gitlab_url

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,12 +1,12 @@
 # GitLab user. git by default
 user: git
 
-# Url to gitlab instance. Used for api calls. Should end with a slash.
-# Default: http://localhost:8080/
+# Url to gitlab instance. Used for api calls.
+# Default: http://localhost:8080
 # You only have to change the default if you have configured Unicorn
 # to listen on a custom port, or if you have configured Unicorn to
 # only listen on a Unix domain socket.
-gitlab_url: "http://localhost:8080/"
+gitlab_url: "http://localhost:8080"
 
 # See installation.md#using-https for additional HTTPS configuration details.
 http_settings:


### PR DESCRIPTION
As per @jacobvosmaer at https://github.com/gitlabhq/omnibus-gitlab/commit/6c500427c611ff9b8452e9351df9f55682910d15#commitcomment-8654724 no longer needed.
