### PR TITLE
Allow administrators to log users' IP

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -46,3 +46,6 @@ log_level: INFO
 # Set to true to see real usernames in the logs instead of key ids, which is easier to follow, but
 # incurs an extra API call on every gitlab-shell command.
 audit_usernames: false
+
+# Audit client IP
+audit_client_ip: false

--- a/lib/gitlab_config.rb
+++ b/lib/gitlab_config.rb
@@ -47,6 +47,10 @@ class GitlabConfig
     @config['audit_usernames'] ||= false
   end
 
+  def audit_client_ip
+    @config['audit_client_ip'] ||= false
+  end
+
   # Build redis command to write update event in gitlab queue
   def redis_command
     if redis.empty?

--- a/spec/gitlab_config_spec.rb
+++ b/spec/gitlab_config_spec.rb
@@ -43,6 +43,12 @@ eos
     it("returns false by default") { should eq(false) }
   end
 
+  describe :audit_client_ip do
+    subject { config.audit_client_ip }
+
+    it("returns false by default") { should eq(false) }
+  end
+
   describe :redis_command do
     subject { config.redis_command }
 

--- a/spec/gitlab_shell_spec.rb
+++ b/spec/gitlab_shell_spec.rb
@@ -19,7 +19,8 @@ describe GitlabShell do
   let(:key_id) { "key-#{rand(100) + 100}" }
   let(:repository_path) { "/home/git#{rand(100)}/repos" }
   before do
-    GitlabConfig.any_instance.stub(repos_path: repository_path, audit_usernames: false)
+    GitlabConfig.any_instance.stub(repos_path: repository_path, audit_usernames: false, audit_client_ip: false)
+    ssh_client_ip '1.2.3.4'
   end
 
   describe :initialize do
@@ -86,6 +87,11 @@ describe GitlabShell do
       it "should use usernames if configured to do so" do
         GitlabConfig.any_instance.stub(audit_usernames: true)
         $logger.should_receive(:info) { |msg| msg.should =~ /for John Doe/ }
+      end
+
+      it "should log users' IP if configured to do so" do
+        GitlabConfig.any_instance.stub(audit_client_ip: true)
+        $logger.should_receive(:info) { |msg| msg.should =~ /from 1.2.3.4/ }
       end
     end
 
@@ -181,6 +187,10 @@ describe GitlabShell do
 
   def ssh_cmd(cmd)
     ENV['SSH_ORIGINAL_COMMAND'] = cmd
+  end
+
+  def ssh_client_ip(ip)
+    ENV['SSH_CONNECTION'] = "#{ip} 12345 12.34.56.78 54321"
   end
 
 end


### PR DESCRIPTION
The log will contain client's IP when `audit_client_ip` is enabled. E.g.,

```
I, [2015-01-13T23:15:14.547808 #10575]  INFO -- : gitlab-shell: executing git command <git-upload-pack /var/opt/gitlab/git-data/repositories/test/test.git> for user-1 with key key-27 from 1.2.3.4.
```

Signed-off-by: kfei kfei@kfei.net
