### PR TITLE
forcing @changes to be array

### DIFF
--- a/lib/gitlab_access.rb
+++ b/lib/gitlab_access.rb
@@ -19,7 +19,12 @@ class GitlabAccess
 
   def exec
     begin
-      status = api.check_access('git-receive-pack', @repo_name, @actor, @changes.to_a)
+      status = api.check_access(
+                                'git-receive-pack', 
+                                @repo_name, 
+                                @actor, 
+                                @changes.to_a
+                                )
 
       return true if status.allowed?
 

--- a/lib/gitlab_access.rb
+++ b/lib/gitlab_access.rb
@@ -19,7 +19,7 @@ class GitlabAccess
 
   def exec
     begin
-      status = api.check_access('git-receive-pack', @repo_name, @actor, @changes)
+      status = api.check_access('git-receive-pack', @repo_name, @actor, @changes.to_a)
 
       return true if status.allowed?
 

--- a/lib/gitlab_access.rb
+++ b/lib/gitlab_access.rb
@@ -20,11 +20,11 @@ class GitlabAccess
   def exec
     begin
       status = api.check_access(
-                                'git-receive-pack', 
-                                @repo_name, 
-                                @actor, 
-                                @changes.to_a
-                                )
+        'git-receive-pack',
+        @repo_name,
+        @actor,
+        @changes.to_a
+      )
 
       return true if status.allowed?
 


### PR DESCRIPTION
After nightly upgrade to GL `v7.8.2` and GS `v2.5.4`, while pushing to existing repo I get erro:

```
$ git push origin master
Counting objects: 5, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 311 bytes | 0 bytes/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: /home/git/gitlab-shell/lib/gitlab_net.rb:16:in `check_access': undefined method `join' for #<Enumerator:0x0000000199f8a8> (NoMethodError)
remote:     from /home/git/gitlab-shell/lib/gitlab_access.rb:22:in `exec'
remote:     from hooks/pre-receive:13:in `<main>'
To git@git.EXAMPLE.COM:XXX/YYY.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'git@git.EXAMPLE.COM:XXX/YYY.git'
$
```

So here's my quickfix, which fixed this error on my server..
