### PR TITLE
Specify a secret_token as URL parameter in a GET request

### DIFF
--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -151,14 +151,21 @@ class GitlabNet
   end
 
   def http_request_for(method, uri, params = {})
-    request_klass = method == :get ? Net::HTTP::Get : Net::HTTP::Post
-    request = request_klass.new(uri.request_uri)
+    url = uri.request_uri
+
+    case method
+    when :get
+      url += (url.include?('?') ? '&' : '?') +
+             URI.encode_www_form(secret_token: secret_token)
+      request = Net::HTTP::Get.new(url)
+    else
+      request = Net::HTTP::Post.new(url)
+      request.set_form_data(params.merge(secret_token: secret_token))
+    end
 
     user = config.http_settings['user']
     password = config.http_settings['password']
     request.basic_auth(user, password) if user && password
-
-    request.set_form_data(params.merge(secret_token: secret_token))
 
     request
   end

--- a/spec/vcr_cassettes/broadcast_message-none.yml
+++ b/spec/vcr_cassettes/broadcast_message-none.yml
@@ -2,10 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/broadcast_message
-    body:
-      encoding: US-ASCII
-      string: secret_token=a123
+    uri: https://dev.gitlab.org/api/v3/internal/broadcast_message?secret_token=a123
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr_cassettes/broadcast_message-ok.yml
+++ b/spec/vcr_cassettes/broadcast_message-ok.yml
@@ -2,10 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/broadcast_message
-    body:
-      encoding: US-ASCII
-      string: secret_token=a123
+    uri: https://dev.gitlab.org/api/v3/internal/broadcast_message?secret_token=a123
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr_cassettes/check-ok.yml
+++ b/spec/vcr_cassettes/check-ok.yml
@@ -2,10 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/check
-    body:
-      encoding: US-ASCII
-      string: secret_token=a123
+    uri: https://dev.gitlab.org/api/v3/internal/check?secret_token=a123
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr_cassettes/discover-ok.yml
+++ b/spec/vcr_cassettes/discover-ok.yml
@@ -2,10 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.gitlab.org/api/v3/internal/discover?key_id=126
-    body:
-      encoding: US-ASCII
-      string: secret_token=a123
+    uri: https://dev.gitlab.org/api/v3/internal/discover?key_id=126&secret_token=a123
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3


### PR DESCRIPTION
Making a GET request with a body renders some WWW server/middleware implementations to fail or stall.

In my case, I'm running GitLab on Apache 2.2 + Passenger 5 and every invocation of `git push` stalls until a GET request (broadcase_message) in gitlab-shell times out.  Here's a trace of a failure found in my gitlab-shell.log:

```
W, [2015-05-15T22:11:35.607297 #63785]  WARN -- : Failed to connect to internal API <GET https://[redacted]/api/v3/internal/broadcast_message>: #<Net::ReadTimeout: Net::ReadTimeout>
```
