### PR TITLE
Do not clean LANG environment variable for the git hooks when working through the SSH-protocol

### DIFF
--- a/lib/gitlab_shell.rb
+++ b/lib/gitlab_shell.rb
@@ -122,6 +122,7 @@ class GitlabShell
     env = {
       'PATH' => ENV['PATH'],
       'LD_LIBRARY_PATH' => ENV['LD_LIBRARY_PATH'],
+      'LANG' => ENV['LANG'],
       'GL_ID' => @key_id
     }
 


### PR DESCRIPTION
When cleaning this environment variable can be problems with the processing of non-ASCII data