### PR TITLE
Run git-lfs-authenticate script with original command line arguments

### DIFF
--- a/lib/gitlab_shell.rb
+++ b/lib/gitlab_shell.rb
@@ -111,6 +111,8 @@ class GitlabShell
 
       $logger.info "gitlab-shell: executing git-annex command <#{parsed_args.join(' ')}> for #{log_username}."
       exec_cmd(*parsed_args)
+    elsif @git_cmd == 'git-lfs-authenticate'
+      exec_cmd(@origin_cmd)
     else
       $logger.info "gitlab-shell: executing git command <#{@git_cmd} #{repo_full_path}> for #{log_username}."
       exec_cmd(@git_cmd, repo_full_path)


### PR DESCRIPTION
Some time ago gitlab allow the command git-lfs-authenticate via ssh to provide SSO-login between gitlab and git-lfs (2f19152047b6f8e6d8cf8ad757370cfcb8a3581b).

Unfortunately, at the moment the command is received not a standard list of arguments. This change passes arguments from the user in git-lfs-authenticate in its original form.

Just sorry that my previous commit don't contain this change :(