### PR TITLE
Custom hooks: flush output immediatly

### DIFF
--- a/lib/gitlab_custom_hook.rb
+++ b/lib/gitlab_custom_hook.rb
@@ -48,11 +48,14 @@ class GitlabCustomHook
       # need to close stdin before reading stdout
       stdin.close
 
+      stdout_stderr.each_line do |line| 
+        puts line 
+        $stdout.flush
+      end
+      
       unless wait_thr.value == 0
         exit_status = false
       end
-
-      stdout_stderr.each_line { |line| puts line }
     end
 
     exit_status

--- a/lib/gitlab_custom_hook.rb
+++ b/lib/gitlab_custom_hook.rb
@@ -33,6 +33,7 @@ class GitlabCustomHook
     Open3.popen2e(hook) do |stdin, stdout_stderr, wait_thr|
       exit_status = true
       stdin.sync = true
+      $stdout.sync = true
 
       # in git, pre- and post- receive hooks may just exit without
       # reading stdin. We catch the exception to avoid a broken pipe
@@ -48,10 +49,7 @@ class GitlabCustomHook
       # need to close stdin before reading stdout
       stdin.close
 
-      stdout_stderr.each_line do |line|
-        puts line
-        $stdout.flush
-      end
+      stdout_stderr.each_line { |line| puts line }
 
       unless wait_thr.value == 0
         exit_status = false

--- a/lib/gitlab_custom_hook.rb
+++ b/lib/gitlab_custom_hook.rb
@@ -48,11 +48,11 @@ class GitlabCustomHook
       # need to close stdin before reading stdout
       stdin.close
 
-      stdout_stderr.each_line do |line| 
-        puts line 
+      stdout_stderr.each_line do |line|
+        puts line
         $stdout.flush
       end
-      
+
       unless wait_thr.value == 0
         exit_status = false
       end


### PR DESCRIPTION
I have a long running custom_hook, right now I don't see the output until the script finished. With this change the output is sent immediatly to the user.
