### PR TITLE
Add Merge Request url on post-receive hook

### DIFF
--- a/lib/gitlab_merge_request_hook.rb
+++ b/lib/gitlab_merge_request_hook.rb
@@ -1,0 +1,37 @@
+require_relative 'gitlab_init'
+
+class GitlabMergeRequestHook
+  attr_reader :config, :repo_path, :changes
+
+  def initialize(repo_path, config, changes)
+    @branch    = branch_name(changes)
+    @config    = config
+    @repo_path = repo_path
+  end
+
+  def exec
+    return if @branch.nil? || @branch == 'master'
+    puts
+    puts "To open a merge request for #{@branch}, enter in:"
+    puts "\t#{repo_url}"
+    puts
+  end
+
+  private
+
+  def branch_name(changes)
+    changes.
+      encode('UTF-8', 'binary', invalid: :replace, replace: '').
+      split.
+      select { |change| change.include?('refs/head') }.
+      last.gsub!('refs/heads/', '') rescue nil
+  end
+
+  def repo_url
+    repo_url = @repo_path.split('/').last(2).join('/')
+    repo_url.gsub!(/\.git\z/, '')
+    "#{@config.gitlab_url}/#{repo_url}/merge_requests/new?" \
+      "merge_request[source_branch]=#{@branch}&merge_request[target_branch]=master"
+  end
+
+end

--- a/lib/gitlab_post_receive.rb
+++ b/lib/gitlab_post_receive.rb
@@ -1,5 +1,6 @@
 require_relative 'gitlab_init'
 require_relative 'gitlab_net'
+require_relative 'gitlab_merge_request_hook'
 require 'json'
 require 'base64'
 
@@ -22,6 +23,7 @@ class GitlabPostReceive
         puts
         print_broadcast_message(broadcast_message["message"])
       end
+      GitlabMergeRequestHook.new(@repo_path, @config, @changes).exec
     rescue GitlabNet::ApiUnreachableError
       nil
     end

--- a/spec/gitlab_merge_request_hook_spec.rb
+++ b/spec/gitlab_merge_request_hook_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'gitlab_merge_request_hook'
+
+describe GitlabMergeRequestHook do
+  let(:changes)         { "123456 789012 refs/heads/#{branch_name}" }
+  let(:config)          { GitlabConfig.new }
+  let(:repository_path) { '/home/git/repositories' }
+  let(:repo_name)       { 'dzaporozhets/gitlab-ci' }
+  let(:repo_path)       { File.join(repository_path, repo_name) + '.git' }
+  let(:hook)            { described_class.new(repo_path, config, changes) }
+
+  before do
+    GitlabConfig.any_instance.stub(repos_path: repository_path)
+    GitlabConfig.any_instance.stub(gitlab_url: 'http://mygitlab.com')
+  end
+
+  describe '#exec' do
+    subject { hook.exec }
+
+    context 'pushing on master' do
+      let(:branch_name) { 'master' }
+
+      it 'does not print the merge request url' do
+        expect(hook).not_to receive(:puts)
+        subject
+      end
+    end
+
+    context 'pushing on another branch' do
+      let(:branch_name) { 'my_branch' }
+
+      it 'prints the branch url' do
+        expect(hook).to receive(:puts).ordered
+
+        expect(hook).to receive(:puts).with(
+          'To open a merge request for my_branch, enter in:'
+        )
+
+        expect(hook).to receive(:puts).with(
+          "\thttp://mygitlab.com/dzaporozhets/gitlab-ci/merge_requests/new?" \
+            'merge_request[source_branch]=my_branch&' \
+            'merge_request[target_branch]=master'
+        )
+
+        expect(hook).to receive(:puts).ordered
+
+        subject
+      end
+
+      context 'pushing only tags' do
+        let(:changes) { '654321 210987 refs/tags/tag' }
+
+        it 'does not print the merge request url' do
+          expect(hook).not_to receive(:puts)
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/gitlab_post_receive_spec.rb
+++ b/spec/gitlab_post_receive_spec.rb
@@ -38,7 +38,7 @@ describe GitlabPostReceive do
         "    message message message message message message message message"
       ).ordered
 
-      expect(gitlab_post_receive).to receive(:puts).ordered      
+      expect(gitlab_post_receive).to receive(:puts).ordered
       expect(gitlab_post_receive).to receive(:puts).with(
         "========================================================================"
       ).ordered
@@ -49,7 +49,7 @@ describe GitlabPostReceive do
     it "pushes a Sidekiq job onto the queue" do
       expect(gitlab_post_receive).to receive(:system).with(
         *[
-          *%w(env -i redis-cli rpush resque:gitlab:queue:post_receive), 
+          *%w(env -i redis-cli rpush resque:gitlab:queue:post_receive),
           %Q/{"class":"PostReceive","args":["#{repo_path}","#{actor}",#{base64_changes.inspect}]}/,
           { err: "/dev/null", out: "/dev/null" }
         ]


### PR DESCRIPTION
This change adds the option to print the merge request URL on terminal output after the user pushes into a branch. Like bitbucket does.

I don't know if this is a feature that gitlab wants, but if so and this needs to be changed, feel free to tell me. Thanks :beers: 

<img width="1254" alt="screen shot 2016-01-23 at 10 18 29 pm" src="https://cloud.githubusercontent.com/assets/771411/12533902/28989d72-c221-11e5-90ae-4b4028e5ba85.png">
If this is a valid idea, maybe would be nice to create a url to be more beauty in the terminal output.. =)