### PR TITLE
Chain custom hooks

### DIFF
--- a/lib/gitlab_custom_hook.rb
+++ b/lib/gitlab_custom_hook.rb
@@ -5,8 +5,8 @@ class GitlabCustomHook
   def pre_receive(changes, repo_path)
     hooks = hook_files('pre-receive', repo_path)
     return true if hooks.nil?
-    hooks.each do | hook |
-      return false if not call_receive_hook(hook, changes)
+    hooks.each do |hook|
+      return false unless call_receive_hook(hook, changes)
     end
     true
   end
@@ -14,8 +14,8 @@ class GitlabCustomHook
   def post_receive(changes, repo_path)
     hooks = hook_files('post-receive', repo_path)
     return true if hooks.nil?
-    hooks.each do | hook |
-      return false if not call_receive_hook(hook, changes)
+    hooks.each do |hook|
+      return false unless call_receive_hook(hook, changes)
     end
     true
   end
@@ -23,8 +23,8 @@ class GitlabCustomHook
   def update(ref_name, old_value, new_value, repo_path)
     hooks = hook_files('update', repo_path)
     return true if hooks.nil?
-    hooks.each do | hook |
-      if not system(hook, ref_name, old_value, new_value)
+    hooks.each do |hook|
+      unless system(hook, ref_name, old_value, new_value)
         return false
       end
     end


### PR DESCRIPTION
Add optional use of chained custom commit hooks in group directory and git directory.

This was the order:
repositories/<group>/<repo>.git/custom_hooks/pre-commit
repositories/<group>/<repo>.git/custom_hooks/update
repositories/<group>/<repo>.git/custom_hooks/post-commit

This is now the order:
repositories/<group>/custom_hooks/pre-commit.d/
repositories/<group>/custom_hooks/pre-commit
repositories/<group>/custom_hooks/update.d/
repositories/<group>/custom_hooks/update
repositories/<group>/custom_hooks/post-commit.d/
repositories/<group>/custom_hooks/post-commit

repositories/<group>/<repo>.git/custom_hooks/pre-commit.d/
repositories/<group>/<repo>.git/custom_hooks/pre-commit
repositories/<group>/<repo>.git/custom_hooks/update.d/
repositories/<group>/<repo>.git/custom_hooks/update
repositories/<group>/<repo>.git/custom_hooks/post-commit.d/
repositories/<group>/<repo>.git/custom_hooks/post-commit

This won't change anything for existing implementations (unless there's accidentally a valid new directory/file of course).
