### PR TITLE
Use query params when doing a GET request.

### DIFF
--- a/lib/gitlab_net.rb
+++ b/lib/gitlab_net.rb
@@ -151,13 +151,18 @@ class GitlabNet
 
   def http_request_for(method, uri, params = {})
     request_klass = method == :get ? Net::HTTP::Get : Net::HTTP::Post
+
+    params.merge!(secret_token: secret_token)
+
+    uri.query = URI.encode_www_form( params ) if method == :get
+
     request = request_klass.new(uri.request_uri)
 
     user = config.http_settings['user']
     password = config.http_settings['password']
     request.basic_auth(user, password) if user && password
 
-    request.set_form_data(params.merge(secret_token: secret_token))
+    request.set_form_data(params)
 
     request
   end


### PR DESCRIPTION
Fixes 401 not allowed error on  `gitlab-shell/bin/check`

Some webservers do not pass through request body for GET requests when doing reverse proxy (e.g. cherokee). If the request 
method is GET, pass the parameters via query params.