### PR TITLE
Fix Voice in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 GitLab Shell handles git SSH sessions for GitLab and modifies the list of authorized keys.
 GitLab Shell is not a Unix shell nor a replacement for Bash or Zsh.
 
-When you access the GitLab server over SSH then GitLab Shell will:
+When you access the GitLab server over SSH, then GitLab Shell will:
 
 1. Limits you to predefined git commands (git push, git pull).
 1. Call the GitLab Rails API to check if you are authorized, and what Gitaly server your repository is on
 1. Copy data back and forth between the SSH client and the Gitaly server
 
-If you access a GitLab server over HTTP(S) you end up in [gitlab-workhorse](https://gitlab.com/gitlab-org/gitlab-workhorse).
+If you access a GitLab server over HTTP(S), you end up in [gitlab-workhorse](https://gitlab.com/gitlab-org/gitlab-workhorse).
 
 An overview of the four cases described above:
 
@@ -26,7 +26,7 @@ An overview of the four cases described above:
 
 ## Requirements
 
-GitLab Shell is written in Go, and needs a Go compiler to build. It still requires
+GitLab Shell is written in Go and needs a Go compiler to build. It still requires
 Ruby to build and test, but not to run.
 
 Download and install the current version of Go from https://golang.org/dl/
@@ -37,7 +37,7 @@ Download and install the current version of Go from https://golang.org/dl/
 
 ## Check
 
-Checks if GitLab API access and redis via internal API can be reached:
+Checks if you can reach GitLab API access and Redis via internal API:
 
     make check
 
@@ -64,8 +64,8 @@ Starting with GitLab 8.12, GitLab supports Git LFS authentication through SSH.
 
 ## Releasing a new version
 
-GitLab Shell is versioned by git tags, and the version used by the Rails
-application is stored in
+Git tags version GitLab Shell, and the version used by the Rails
+application is store in
 [`GITLAB_SHELL_VERSION`](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/GITLAB_SHELL_VERSION).
 
 For each version, there is a raw version and a tag version:
@@ -78,11 +78,10 @@ Rails application:
 
 1. Create a merge request to update the [`CHANGELOG`](CHANGELOG) with the
    **tag version** and the [`VERSION`](VERSION) file with the **raw version**.
-2. Ask a maintainer to review and merge the merge request. If you're already a
+2. Ask a maintainer to review and merge the merge request. If you are already a
    maintainer, second maintainer review is not required.
 3. Add a new git tag with the **tag version**.
-4. Update `GITLAB_SHELL_VERSION` in the Rails application to the **raw
-   version**. (Note: this can be done as a separate MR to that, or in and MR
+4. Update `GITLAB_SHELL_VERSION` in the Rails application to the **raw version**. (Note: we can do this as a separate MR to that, or in and MR
    that will make use of the latest GitLab Shell changes.)
 
 ## Contributing


### PR DESCRIPTION
Some sentences are in the passive voice, and it is clouding the meaning of your sentences. So, to make it's meaning clear for readers, and keep the sentences from becoming too complicated or wordy, I changed them all to Active Voice.
Also, added punctuations.