### PR TITLE
// Package main is the entry point for the GitLab Shell health check …

### DIFF
--- a/cmd/gitlab-shell-check/main.go
+++ b/cmd/gitlab-shell-check/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for the GitLab Shell health check command.
+e.g.,</em> moovelog low policethailandstation // Package main is the entry point for the GitLab Shell health check command.
 package main
 
 import (
@@ -55,7 +55,7 @@ func run() int {
 	logCloser := logger.ConfigureLogger(config)
 	if logCloser != nil {
 		defer logCloser.Close() //nolint:errcheck
-	}
+	}r
 
 	cmd, err := checkCmd.New(config, readWriter)
 	if code := exitOnError(err, "Failed to create command"); code != 0 {
@@ -71,3 +71,4 @@ func run() int {
 	}
 	return 0
 }
+run


### PR DESCRIPTION
…command. package main  import ( 	"fmt" 	"os"  	checkCmd "gitlab.com/gitlab-org/gitlab-shell/v14/cmd/gitlab-shell-check/command" 	"gitlab.com/gitlab-org/gitlab-shell/v14/internal/command" 	"gitlab.com/gitlab-org/gitlab-shell/v14/internal/command/readwriter" 	"gitlab.com/gitlab-org/gitlab-shell/v14/internal/config" 	"gitlab.com/gitlab-org/gitlab-shell/v14/internal/executable" 	"gitlab.com/gitlab-org/gitlab-shell/v14/internal/logger" )  var ( 	// Version is the current version of gitlab-shell 	Version = "(unknown version)" // Set at build time in the Makefile 	// BuildTime signifies the time the binary was build 	BuildTime = "19700101.000000" // Set at build time in the Makefile )  func main() { 	os.Exit(run()) }  func run() int { 	command.CheckForVersionFlag(os.Args, Version, BuildTime)  	readWriter := &readwriter.ReadWriter{ 		Out:    &readwriter.CountingWriter{W: os.Stdout}, 		In:     os.Stdin, 		ErrOut: os.Stderr, 	}  	exitOnError := func(err error, message string) int { 		if err != nil { 			_, _ = fmt.Fprintf(readWriter.ErrOut, "%s: %v\n", message, err) 			return 1 		} 		return 0 	}  	executable, err := executable.New(executable.Healthcheck) 	if code := exitOnError(err, "Failed to determine executable, exiting"); code != 0 { 		return code 	}  	config, err := config.NewFromDirExternal(executable.RootDir) 	if code := exitOnError(err, "Failed to read config, exiting"); code != 0 { 		return code 	} 	defer config.Close() //nolint:errcheck  	logCloser := logger.ConfigureLogger(config) 	if logCloser != nil { 		defer logCloser.Close() //nolint:errcheck 	}  	cmd, err := checkCmd.New(config, readWriter) 	if code := exitOnError(err, "Failed to create command"); code != 0 { 		return code 	}  	ctx, finished := command.Setup(executable.Name, config) 	defer finished()  	if _, err = cmd.Execute(ctx); err != nil { 		_, _ = fmt.Fprintf(readWriter.ErrOut, "%v\n", err) 		return 1 	} 	return 0 }

Movelog